### PR TITLE
Fix exception generated when changing model without updating password

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,22 @@ You can contribute by doing the following:
 * Commit
 * Send a pull request
 
+### Testing contributions
+
+The repository contains a dummy rails app for use as a test harness. To run tests within your cloned
+repository you will need to:
+
+```
+bundle
+cd test/dummy
+bundle exec rails db:migrate
+cd ../..
+```
+
+Once that is done you can execute the test suite with:
+
+```bundle exec rake test```
+
+
 ## License
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/lib/devise/uncommon_password/model.rb
+++ b/lib/devise/uncommon_password/model.rb
@@ -25,6 +25,8 @@ module Devise
       private
 
       def not_common_password
+        return unless password.present?
+
         if Devise::Models::UncommonPassword.common_passwords.include? password.downcase
           errors.add(:password, "is a very common password. Please choose something harder to guess.")
         end

--- a/test/devise/uncommon_password_test.rb
+++ b/test/devise/uncommon_password_test.rb
@@ -22,4 +22,12 @@ class Devise::UncommonPassword::Test < ActiveSupport::TestCase
     user = User.create email:"example@example.org", password: password, password_confirmation: password
     assert user.valid?, "User with uncommon password should be valid."
   end
+
+  test "should not attempt to validate if model changed without updating password" do
+    password = "fddkasnsdddghjt"
+    User.create email:"example@example.org", password: password, password_confirmation: password
+
+    update = User.where(email: 'example@example.org').first.update_attributes(email: 'anotherexample@example.org')
+    assert update
+  end
 end


### PR DESCRIPTION
In one of my applications I use my devise model for information beyond just credentials. That means that we will often be updating details without changing the password.

Having added devise-uncommon_password I was seeing an exception of

```undefined method `downcase' for nil:NilClass```

when doing those updates, because the validation would attempt to run against a value that wasn't set.

This change skips the validation if no password is given.