### PR TITLE
Bump support to < devise 4.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     devise-uncommon_password (0.3.3)
-      devise (>= 3.5, < 4.5)
+      devise (>= 3.5, < 4.6)
       rails (>= 4.2, < 5.3)
 
 GEM
@@ -69,13 +69,13 @@ GEM
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-    marcel (0.3.2)
+    marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
     mimemagic (0.3.2)
-    mini_mime (1.0.0)
+    mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     nio4r (2.3.1)
@@ -113,7 +113,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -141,4 +141,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.1
+   1.16.6

--- a/devise-uncommon_password.gemspec
+++ b/devise-uncommon_password.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", ">= 4.2", "< 5.3"
-  s.add_dependency "devise", ">= 3.5", "< 4.5"
+  s.add_dependency "devise", ">= 3.5", "< 4.6"
 
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
We're just upgrading to Devise 4.5 but also want to use this gem in coordination with it.

I ran the tests against 4.5 and saw no regressions. 