### PR TITLE
Bump support for Devise 4.6.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    devise-uncommon_password (0.3.3)
-      devise (>= 3.5, < 4.6)
+    devise-uncommon_password (0.3.4)
+      devise (>= 3.5, < 4.7)
       rails (>= 4.2, < 5.3)
 
 GEM
@@ -62,7 +62,7 @@ GEM
       responders
       warden (~> 1.2.3)
     erubi (1.7.1)
-    globalid (0.4.1)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
@@ -74,7 +74,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.1)
-    mimemagic (0.3.2)
+    mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -141,4 +141,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/devise-uncommon_password.gemspec
+++ b/devise-uncommon_password.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", ">= 4.2", "< 5.3"
-  s.add_dependency "devise", ">= 3.5", "< 4.6"
+  s.add_dependency "devise", ">= 3.5", "< 4.7"
 
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
With [CVE-2019-5421](https://github.com/plataformatec/devise/issues/4981) reported + patched in 4.6, `devise-uncommon_password` blocks updating to the fixed minor version.

Quick dependency bump, no issues running locally.