### PR TITLE
Handle a nil password when not_common_password validation runs

### DIFF
--- a/lib/devise/uncommon_password/model.rb
+++ b/lib/devise/uncommon_password/model.rb
@@ -31,7 +31,7 @@ module Devise
       private
 
       def not_common_password
-        if Devise::Models::UncommonPassword.common_passwords.include? password.downcase
+        if password && Devise::Models::UncommonPassword.common_passwords.include?(password.downcase)
           errors.add(:password, "is a very common password. Please choose something harder to guess.")
         end
       end

--- a/test/devise/uncommon_password_test.rb
+++ b/test/devise/uncommon_password_test.rb
@@ -48,4 +48,10 @@ class Devise::UncommonPassword::Test < ActiveSupport::TestCase
 
     assert user.update_attributes(email: 'anotherexample@example.org')
   end
+
+  test "should run validation without error when password is nil" do
+    user = User.new email:"example@example.org", password: nil
+
+    assert_not user.valid?
+  end
 end


### PR DESCRIPTION
We were experiencing `undefined method `downcase' for nil:NilClass` in our project when we tried to create a user without specifying a password. This fixes the problem.