### PR TITLE
Add nil-check to not_common_password method

### DIFF
--- a/lib/devise/uncommon_password/model.rb
+++ b/lib/devise/uncommon_password/model.rb
@@ -31,7 +31,7 @@ module Devise
       private
 
       def not_common_password
-        if Devise::Models::UncommonPassword.common_passwords.include? password.downcase
+        if Devise::Models::UncommonPassword.common_passwords.include? password&.downcase
           errors.add(:password, "is a very common password. Please choose something harder to guess.")
         end
       end


### PR DESCRIPTION
This fix prevents the error "undefined method 'downcase' for nil: NilClass" when the user doesn't set the password.