### PR TITLE
Remove Rails 7.x version restriction

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    devise-uncommon_password (0.4.3)
+    devise-uncommon_password (0.4.4)
       devise (>= 3.5, < 5.0)
-      rails (>= 4.2, < 7.1)
+      rails (>= 4.2, < 8.0)
 
 GEM
   remote: https://rubygems.org/
@@ -78,6 +78,7 @@ GEM
     byebug (11.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
+    date (3.3.3)
     devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -85,29 +86,33 @@ GEM
       responders
       warden (~> 1.2.3)
     erubi (1.12.0)
-    globalid (1.1.0)
-      activesupport (>= 5.0)
+    globalid (1.2.1)
+      activesupport (>= 6.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.7.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
-    mini_mime (1.1.2)
+    mini_mime (1.1.5)
     mini_portile2 (2.8.2)
     minitest (5.19.0)
-    net-imap (0.3.1)
+    net-imap (0.4.1)
+      date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.1.3)
+    net-protocol (0.2.1)
       timeout
-    net-smtp (0.3.2)
+    net-smtp (0.4.0)
       net-protocol
-    nio4r (2.5.8)
+    nio4r (2.5.9)
     nokogiri (1.15.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -156,12 +161,12 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.4.4)
     thor (1.2.1)
-    timeout (0.3.0)
+    timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    websocket-driver (0.7.5)
+    websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.6.6)

--- a/devise-uncommon_password.gemspec
+++ b/devise-uncommon_password.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7.0"
 
-  s.add_dependency "rails", ">= 4.2", "< 7.1"
+  s.add_dependency "rails", ">= 4.2", "< 8.0"
   s.add_dependency "devise", ">= 3.5", "< 5.0"
 
   s.add_development_dependency "sqlite3", ">= 1.3.6", "< 1.5"


### PR DESCRIPTION
Fixes #58

### Removed
- Restriction on Rails 7 minor version, allowing support up until the next major version

It might be good to consider adding support for [Appraisal](https://github.com/thoughtbot/appraisal) in the future to make these kind of upgrades easier :)