### PR TITLE
[IS-4171] fix: ignore nil passwords

### DIFF
--- a/lib/devise/uncommon_password/model.rb
+++ b/lib/devise/uncommon_password/model.rb
@@ -30,7 +30,7 @@ module Devise
       private
 
       def not_common_password
-        if Devise::Models::UncommonPassword.common_passwords.include? password.downcase
+        if Devise::Models::UncommonPassword.common_passwords.include? password&.downcase
           errors.add(:password, :common_password)
         end
       end


### PR DESCRIPTION
When there are suspicious requests to the "create user" endpoint, `password` param is not always set and the module explodes due to `undefined method downcase for nil:NilClass` error.

As there is another module for validating password length (Devise's built-in), this one should check password against the list of commond password only if the password is present

Password is missing when an incorrect requests to the user registration endpoint are made, example:

```bash
curl -v 'http://localhost:3002/users' -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' --data ''
```